### PR TITLE
auth: Fix deployment initially authed issue

### DIFF
--- a/script/IAuthChaincheck.sol
+++ b/script/IAuthChaincheck.sol
@@ -13,17 +13,17 @@ import {IAuth} from "src/auth/IAuth.sol";
  * @notice IAuth's `chaincheck` Integration Test
  *
  * @dev Config Definition:
- * ```json
- * {
- *     "IAuth": {
- *         "legacy": bool,
- *         "authed": [
- *             "0x000000000000000000000000000000000000cafe",
- *             ...
- *         ]
- *     }
- * }
- * ```
+ *      ```json
+ *      {
+ *          "IAuth": {
+ *              "legacy": bool,
+ *              "authed": [
+ *                  "<Ethereum address>",
+ *                  ...
+ *              ]
+ *          }
+ *      }
+ *      ```
  */
 contract IAuthChaincheck is Chaincheck {
     using stdJson for string;

--- a/script/ITollChaincheck.sol
+++ b/script/ITollChaincheck.sol
@@ -14,17 +14,17 @@ import {IToll} from "src/toll/IToll.sol";
  * @notice IToll's `chaincheck` Integration Test
  *
  * @dev Config Definition:
- * ```json
- * {
- *     "IToll": {
- *         "legacy": bool,
- *         "tolled": [
- *             "0x000000000000000000000000000000000000cafe",
- *             ...
- *         ]
- *     }
- * }
- * ```
+ *      ```json
+ *      {
+ *          "IToll": {
+ *              "legacy": bool,
+ *              "tolled": [
+ *                  "<Ethereum address>",
+ *                  ...
+ *              ]
+ *          }
+ *      }
+ *      ```
  */
 contract ITollChaincheck is Chaincheck {
     using stdJson for string;

--- a/src/auth/Auth.sol
+++ b/src/auth/Auth.sol
@@ -10,9 +10,9 @@ import {IAuth} from "./IAuth.sol";
  *      where a set of addresses are granted access to protected functions.
  *      These addresses are said to be _auth'ed_.
  *
- *      Initially, the deployer address is the only address auth'ed. Through
- *      the `rely(address)` and `deny(address)` functions, auth'ed callers are
- *      able to grant/renounce auth to/from addresses.
+ *      Initially, the address given as constructor argument is the only address
+ *      auth'ed. Through the `rely(address)` and `deny(address)` functions,
+ *      auth'ed callers are able to grant/renounce auth to/from addresses.
  *
  *      This module is used through inheritance. It will make available the
  *      modifier `auth`, which can be applied to functions to restrict their
@@ -22,8 +22,8 @@ abstract contract Auth is IAuth {
     /// @dev Mapping storing whether address is auth'ed.
     /// @custom:invariant Image of mapping is {0, 1}.
     ///                     ∀x ∊ Address: _wards[x] ∊ {0, 1}
-    /// @custom:invariant Only deployer address authenticated after deployment.
-    ///                     deployment → (∀x ∊ Address: _wards[x] == 1 → x == msg.sender)
+    /// @custom:invariant Only address given as constructor argument is authenticated after deployment.
+    ///                     deploy(initialAuthed) → (∀x ∊ Address: _wards[x] == 1 → x == initialAuthed)
     /// @custom:invariant Only functions `rely` and `deny` may mutate the mapping's state.
     ///                     ∀x ∊ Address: preTx(_wards[x]) != postTx(_wards[x])
     ///                                     → (msg.sig == "rely" ∨ msg.sig == "deny")
@@ -60,13 +60,13 @@ abstract contract Auth is IAuth {
         _;
     }
 
-    constructor() {
-        _wards[msg.sender] = 1;
-        _wardsTouched.push(msg.sender);
+    constructor(address initialAuthed) {
+        _wards[initialAuthed] = 1;
+        _wardsTouched.push(initialAuthed);
 
-        // Note to use address(0) as caller to keep invariant that no address
-        // can grant itself auth.
-        emit AuthGranted(address(0), msg.sender);
+        // Note to use address(0) as caller to indicate address was auth'ed
+        // during deployment.
+        emit AuthGranted(address(0), initialAuthed);
     }
 
     /// @inheritdoc IAuth

--- a/test/auth/Auth.t.sol
+++ b/test/auth/Auth.t.sol
@@ -6,16 +6,18 @@ import {IAuthInvariantTest} from "./IAuthInvariantTest.sol";
 
 import {Auth} from "src/auth/Auth.sol";
 
-contract AuthInstance is Auth {}
+contract AuthInstance is Auth {
+    constructor(address initialAuthed) Auth(initialAuthed) {}
+}
 
 contract AuthTest is IAuthTest {
     function setUp() public {
-        setUp(new AuthInstance());
+        setUp(new AuthInstance(address(this)));
     }
 }
 
 contract AuthInvariantTest is IAuthInvariantTest {
     function setUp() public {
-        setUp(new AuthInstance());
+        setUp(new AuthInstance(address(this)));
     }
 }

--- a/test/auth/IAuthTest.sol
+++ b/test/auth/IAuthTest.sol
@@ -19,10 +19,10 @@ abstract contract IAuthTest is Test {
     }
 
     function test_deployment() public {
-        // Deployer is auth'ed.
+        // Address given as constructor argument is auth'ed.
         assertTrue(auth.authed(address(this)));
 
-        // Deployer is included in authed list.
+        // Address given as constructor is included in authed list.
         address[] memory authed = auth.authed();
         assertEq(authed.length, 1);
         assertEq(authed[0], address(this));

--- a/test/toll/Toll.t.sol
+++ b/test/toll/Toll.t.sol
@@ -8,17 +8,19 @@ import {Toll} from "src/toll/Toll.sol";
 import {Auth} from "src/auth/Auth.sol";
 
 contract TollInstance is Toll, Auth {
+    constructor(address initialAuthed) Auth(initialAuthed) {}
+
     function toll_auth() internal override(Toll) auth {}
 }
 
 contract TollTest is ITollTest {
     function setUp() public {
-        setUp(new TollInstance());
+        setUp(new TollInstance(address(this)));
     }
 }
 
 contract TollInvariantTest is ITollInvariantTest {
     function setUp() public {
-        setUp(new TollInstance());
+        setUp(new TollInstance(address(this)));
     }
 }


### PR DESCRIPTION
As discussed we adjust the `Auth` module to receive the address being initially auth'ed via the constructor. This fixes issues with regard to deployments using factories.

If merged, we bump the version to v2.0.0.